### PR TITLE
Add variant without useState

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ Este repositorio contiene un ejemplo sencillo de una aplicación de control de i
 ```
 frontend/
   index.html   # Archivo principal que carga la aplicación
-  app.js       # Componentes React para manejar el inventario
+  app.js       # Versión que utiliza useState para manejar el inventario
+  app_no_state.js # Ejemplo sin generadores de estado
 ```
 
 ## Uso
 
 No se requiere compilar ni instalar dependencias. Basta con abrir `frontend/index.html` en un navegador que tenga conexión a Internet para cargar las bibliotecas de React desde un CDN y probar la aplicación.
+
+El archivo `index.html` está configurado para ejecutar `app_no_state.js`, que implementa la lógica sin utilizar `useState`. Si prefieres la versión original basada en `useState`, cambia la referencia del script a `app.js`.
 
 La interfaz permite:
 

--- a/frontend/app_no_state.js
+++ b/frontend/app_no_state.js
@@ -1,0 +1,63 @@
+function renderInventoryApp() {
+  ReactDOM.render(<InventoryApp items={window.inventoryItems} />, document.getElementById('root'));
+}
+
+window.inventoryItems = [
+  { id: 1, name: 'Vodka', quantity: 10 },
+  { id: 2, name: 'Rum', quantity: 5 },
+];
+
+function InventoryApp({ items }) {
+  const nameRef = React.useRef(null);
+  const qtyRef = React.useRef(null);
+
+  const addItem = () => {
+    const name = nameRef.current.value.trim();
+    const qty = qtyRef.current.value;
+    if (!name || qty === '') return;
+    const newItem = { id: items.length ? items[items.length - 1].id + 1 : 1, name, quantity: parseInt(qty, 10) };
+    window.inventoryItems = [...items, newItem];
+    nameRef.current.value = '';
+    qtyRef.current.value = '';
+    renderInventoryApp();
+  };
+
+  const removeItem = (id) => {
+    window.inventoryItems = items.filter((item) => item.id !== id);
+    renderInventoryApp();
+  };
+
+  const updateQuantity = (id, newQty) => {
+    window.inventoryItems = items.map((item) =>
+      item.id === id ? { ...item, quantity: parseInt(newQty, 10) } : item
+    );
+    renderInventoryApp();
+  };
+
+  return (
+    <div>
+      <h1>Bar Inventory Control (Sin useState)</h1>
+      <div>
+        <input placeholder="Item name" ref={nameRef} />
+        <input type="number" placeholder="Quantity" ref={qtyRef} />
+        <button onClick={addItem}>Add</button>
+      </div>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>
+            {item.name} -
+            <input
+              type="number"
+              defaultValue={item.quantity}
+              onChange={(e) => updateQuantity(item.id, e.target.value)}
+              style={{ width: '60px' }}
+            />
+            <button onClick={() => removeItem(item.id)}>Remove</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+renderInventoryApp();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="text/babel" src="app.js"></script>
+  <script type="text/babel" src="app_no_state.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add alternative React implementation that doesn't rely on useState
- load the new variant from index.html
- document both versions in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6841c58209cc832fa8e7d82ce97d3738