### PR TITLE
Add React inventory app with Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
 # Inventory Control Frontend
 
-Este repositorio contiene un ejemplo sencillo de una aplicación de control de inventario para un bar de tragos utilizando React.
+Este repositorio contiene un ejemplo sencillo de una aplicación de control de inventario para un bar de tragos utilizando **React** con **Vite**.
 
 ## Estructura
 
 ```
 frontend/
-  index.html   # Archivo principal que carga la aplicación
-  app.js       # Versión que utiliza useState para manejar el inventario
-  app_no_state.js # Ejemplo sin generadores de estado
+  index.html       # Punto de entrada para Vite
+  package.json     # Dependencias y scripts
+  vite.config.js   # Configuración de Vite
+  src/
+    App.jsx        # Componente principal con la lógica del inventario
+    main.jsx       # Punto de montaje de React
+    *.css          # Estilos
 ```
 
 ## Uso
 
-No se requiere compilar ni instalar dependencias. Basta con abrir `frontend/index.html` en un navegador que tenga conexión a Internet para cargar las bibliotecas de React desde un CDN y probar la aplicación.
+Instala las dependencias y ejecuta el servidor de desarrollo:
 
-El archivo `index.html` está configurado para ejecutar `app_no_state.js`, que implementa la lógica sin utilizar `useState`. Si prefieres la versión original basada en `useState`, cambia la referencia del script a `app.js`.
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
 La interfaz permite:
 
 - Agregar artículos especificando nombre y cantidad.
 - Modificar la cantidad existente de cada artículo.
 - Eliminar artículos de la lista.
-

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inventario de Tragos</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "inventory-vite",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,7 @@
+.app h1 {
+  text-align: center;
+}
+
+.app button {
+  margin-left: 0.25rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import './App.css'
+
+export default function App() {
+  const [items, setItems] = useState([])
+  const [name, setName] = useState('')
+  const [qty, setQty] = useState(1)
+
+  const addItem = (e) => {
+    e.preventDefault()
+    if (!name.trim()) return
+    setItems([...items, { id: Date.now(), name, qty: Number(qty) }])
+    setName('')
+    setQty(1)
+  }
+
+  const updateQty = (id, delta) => {
+    setItems(items.map(item =>
+      item.id === id ? { ...item, qty: item.qty + delta } : item
+    ))
+  }
+
+  const removeItem = (id) => {
+    setItems(items.filter(item => item.id !== id))
+  }
+
+  return (
+    <div className="app">
+      <h1>Inventario de Tragos</h1>
+      <form onSubmit={addItem}>
+        <input
+          type="text"
+          placeholder="Nombre del trago"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          type="number"
+          min="1"
+          value={qty}
+          onChange={e => setQty(e.target.value)}
+        />
+        <button type="submit">Agregar</button>
+      </form>
+      <ul>
+        {items.map(item => (
+          <li key={item.id}>
+            {item.name} - {item.qty}
+            <button onClick={() => updateQty(item.id, 1)}>+</button>
+            <button onClick={() => updateQty(item.id, -1)} disabled={item.qty <= 1}>-</button>
+            <button onClick={() => removeItem(item.id)}>Eliminar</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,42 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 2rem;
+  background-color: #f5f5f5;
+}
+
+.app {
+  max-width: 600px;
+  margin: 0 auto;
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input[type="text"], input[type="number"] {
+  flex: 1;
+  padding: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: '.',
+})


### PR DESCRIPTION
## Summary
- add Vite-based React project under `frontend`
- document how to run the project with npm
- ignore `node_modules` and build output

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841d6cba7d8832f9a1a69eb56f18de9