### PR TITLE
Add card layout with images

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ La interfaz permite:
 - Modificar la cantidad existente de cada artículo.
 - Eliminar artículos de la lista.
 - Al abrir la aplicación se cargan algunos tragos de ejemplo ("Mojito" y "Margarita") para que puedas probar rápidamente.
+- Los artículos se muestran como tarjetas con una imagen generada automáticamente a partir del nombre.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,6 +4,3 @@
   margin-bottom: 1rem;
 }
 
-.app button {
-  margin-left: 0.25rem;
-}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,8 +3,18 @@ import './App.css'
 
 export default function App() {
   const initialItems = [
-    { id: 1, name: 'Mojito', qty: 5 },
-    { id: 2, name: 'Margarita', qty: 3 }
+    {
+      id: 1,
+      name: 'Mojito',
+      qty: 5,
+      img: 'https://via.placeholder.com/150?text=Mojito'
+    },
+    {
+      id: 2,
+      name: 'Margarita',
+      qty: 3,
+      img: 'https://via.placeholder.com/150?text=Margarita'
+    }
   ]
   const [items, setItems] = useState(initialItems)
   const [name, setName] = useState('')
@@ -13,7 +23,15 @@ export default function App() {
   const addItem = (e) => {
     e.preventDefault()
     if (!name.trim()) return
-    setItems([...items, { id: Date.now(), name, qty: Number(qty) }])
+    setItems([
+      ...items,
+      {
+        id: Date.now(),
+        name,
+        qty: Number(qty),
+        img: `https://via.placeholder.com/150?text=${encodeURIComponent(name)}`,
+      },
+    ])
     setName('')
     setQty(1)
   }
@@ -46,16 +64,20 @@ export default function App() {
         />
         <button type="submit">Agregar</button>
       </form>
-      <ul>
+      <div className="cards">
         {items.map(item => (
-          <li key={item.id}>
-            {item.name} - {item.qty}
-            <button onClick={() => updateQty(item.id, 1)}>+</button>
-            <button onClick={() => updateQty(item.id, -1)} disabled={item.qty <= 1}>-</button>
-            <button onClick={() => removeItem(item.id)}>Eliminar</button>
-          </li>
+          <div className="card" key={item.id}>
+            <img src={item.img} alt={item.name} />
+            <h2>{item.name}</h2>
+            <p>Cantidad: {item.qty}</p>
+            <div className="actions">
+              <button onClick={() => updateQty(item.id, 1)}>+</button>
+              <button onClick={() => updateQty(item.id, -1)} disabled={item.qty <= 1}>-</button>
+              <button onClick={() => removeItem(item.id)}>Eliminar</button>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,16 +41,32 @@ button:disabled {
   cursor: not-allowed;
 }
 
-ul {
+.cards {
   list-style: none;
   padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
 }
 
-li {
+.card {
+  background: #fffbea;
+  border: 1px solid #d8c3a5;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  text-align: center;
+}
+
+.card img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.actions {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-  border-bottom: 1px solid #d8c3a5;
-  padding-bottom: 0.25rem;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- show inventory items as cards with placeholder images
- tweak styling for new card layout
- document the updated UI in the README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841f6424650832fb06b9d08a9c570de