### PR TITLE
Fix missing images by using inline placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ La interfaz permite:
 - Eliminar artículos de la lista.
 - Al abrir la aplicación se cargan algunos tragos de ejemplo ("Mojito" y "Margarita") para que puedas probar rápidamente.
 - Los artículos se muestran como tarjetas con una imagen generada automáticamente a partir del nombre.
+- Las imágenes ahora se crean con un pequeño SVG incrustado para que la aplicación funcione incluso sin conexión a internet.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,18 +2,26 @@ import { useState } from 'react'
 import './App.css'
 
 export default function App() {
+  const getPlaceholder = (text) => {
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='150' height='150'>` +
+      `<rect width='100%' height='100%' fill='#ccc'/><text x='50%' y='50%' ` +
+      `dominant-baseline='middle' text-anchor='middle' font-size='20' fill='#555'>` +
+      `${text}</text></svg>`
+    return `data:image/svg+xml,${encodeURIComponent(svg)}`
+  }
+
   const initialItems = [
     {
       id: 1,
       name: 'Mojito',
       qty: 5,
-      img: 'https://via.placeholder.com/150?text=Mojito'
+      img: getPlaceholder('Mojito')
     },
     {
       id: 2,
       name: 'Margarita',
       qty: 3,
-      img: 'https://via.placeholder.com/150?text=Margarita'
+      img: getPlaceholder('Margarita')
     }
   ]
   const [items, setItems] = useState(initialItems)
@@ -29,7 +37,7 @@ export default function App() {
         id: Date.now(),
         name,
         qty: Number(qty),
-        img: `https://via.placeholder.com/150?text=${encodeURIComponent(name)}`,
+        img: getPlaceholder(name),
       },
     ])
     setName('')


### PR DESCRIPTION
## Summary
- generate item images locally using an SVG data URI
- document that images work offline

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68433703a614832f84aeea84408ab536